### PR TITLE
Change file format for whatiscloud.md to ASCII txt

### DIFF
--- a/_docs/whatiscloud.md
+++ b/_docs/whatiscloud.md
@@ -1,9 +1,9 @@
-﻿---
+---
 layout: default
 category: Getting Started
 title: Cloud Services FAQ
 order: 1
-permalink: /clsvcfaq.html
+permalink: /cloud_faq.html
 ---
 
 # Cloud Services FAQ


### PR DESCRIPTION
For some reason, the Jekyll engine won't process files that are of filetype "UTF-8 Unicode", and for some reason this file had the UTF-8 format.

The live version doesn't have a [rendered HTML page for the .md file](https://docs.uwbhacks.com/clsvcfaq.html); this commit should get the Jekyll engine to treat this file properly. (This is a classic _"it works on my machine"_ problem; local testing with the new file format gets the page to populate and show up in the menu.)

```
:) lizzy@cranberries: ~/acm/hackathon_2020/Hackathon-Docs-2020/_docs $ file whatiscloud.md 
whatiscloud.md: UTF-8 Unicode (with BOM) text, with very long lines
:) lizzy@cranberries: ~/acm/hackathon_2020/Hackathon-Docs-2020/_docs $ file template.md 
template.md: ASCII text, with very long lines
```