### PR TITLE
Improve organization & rendering for provider setup page

### DIFF
--- a/_docs/cloud_account_setup.md
+++ b/_docs/cloud_account_setup.md
@@ -12,11 +12,11 @@ For this hackathon, you can create, test, and deploy your project on any
 cloud provider of your choice. This page has resources for account setup 
 and billing considerations for the three main cloud providers:
 
-* AWS
-* Microsoft Azure
-* Google Cloud Platform (GCP)
+* **Amazon Web Services** (AWS)
+* **Microsoft Azure**
+* **Google Cloud Platform** (GCP)
 
-## Billing Considerations & Cost Management
+## Free Accounts
 
 For this hackathon, the applications you create and host will most likely 
 have low traffic and will not be deployed long-term, and the financial 
@@ -25,19 +25,19 @@ the goals of your application, there may be a specific cloud platform
 which meets your needs and will incur the lowest financial cost for your 
 team.
 
-Let's compare and contrast the costs and features of the three primary 
+Two common needs and pain points for students are:
+
+1. Receiving account credits
+2. Requiring a credit card to be on file
+
+Let's compare and contrast the costs and billing requirements of the three primary 
 cloud providers.
 
-| Provider | Free Services | Free Services for Students | Hidden Costs |
-| -------- | ------------- | -------------------------- | ------------ |
-| AWS | AWS has a [Free Tier](https://aws.amazon.com/free/) for most of their common services, which meets most common needs for prototyping applications and small-scale deployment. **No platform credits are provided on the free tier by default.** | AWS has a student program called [AWS Educate](https://aws.amazon.com/education/awseducate/), which provides a $35 platform credit and **does not require a credit card to register**. | Each user's needs will be different, but there are a few common gotchas which tend to inflate AWS costs: <ul><li>Unused or underutilized virtual machines (EC2 instances)</li><li>Unused or underutilized peripherals for EC2 instances (static IP reservations, storage volumes)</li><li>Data transfer costs associated with EBS or S3</li></ul>The primary lessons here are to clean up resources which you don't need and research the costs of services which you plan on utilizing heavily. [Read more about the 'gotchas' here.](https://www.itproportal.com/features/7-hidden-aws-costs-that-could-be-killing-your-budget/) |
-| Google Cloud Platform | GCP has a [Free Tier](https://cloud.google.com/free/); many common services are free to use and **new customers get a $300 platform credit**. | GCP has an [online learning platform](https://edu.google.com/programs/?modal_active=none) which provides free courses to students and faculty. For this hackathon, it isn't a suitable platform. | Many of AWS's hidden costs also apply to GCP services. At scale, GCP seems to be the friendlier platform for cost management, and they have significant advantages in specific service niches.<p>GCP also allows you to set budgets and monitor cost utilization [in a more granular fashion](https://cloud.google.com/billing/docs/how-to/budgets) than [AWS billing monitoring](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html).</p> |
-| Microsoft Azure | Azure has a [Free Tier](https://azure.microsoft.com/en-us/free/); many common services are free to use and **new customers get a $200 platform credit**. | Azure offers [a special platform credit for students](https://azure.microsoft.com/en-us/free/free-account-students-faq/); a $100 platform credit is included and **registration for Azure for Students does not require a credit card on file**. | For enterprise systems and corporate customers, [Azure may provide advantages and disadvantages](https://www.informationweek.com/cloud/infrastructure-as-a-service/hidden-cloud-costs-aws-azure-management-costs-compared/a/d-id/1298029) depending on the existing system configuration, but for students, the difference is likely not noticable. |
-
-For enterprise-level applications, there can be significant monthly bills 
-from cloud providers. Typically these applications produce millions of 
-service activities from thousands of users, and the organization hosting 
-these applications have a business model to support the costs.
+| Provider | Free Services | Free Services for Students |
+| -------- | ------------- | -------------------------- |
+| Amazon Web Services | AWS has a [Free Tier](https://aws.amazon.com/free/) for most of their common services, which meets most common needs for prototyping applications and small-scale deployment. ***No platform credits are provided on the free tier by default.*** | AWS has a student program called [AWS Educate](https://aws.amazon.com/education/awseducate/), which provides a $35 platform credit and ***does not require a credit card to register***. 
+| Google Cloud Platform | GCP has a [Free Tier](https://cloud.google.com/free/); many common services are free to use and ***new customers get a $300 platform credit***. | GCP has an [online learning platform](https://edu.google.com/programs/?modal_active=none) which provides free courses to students and faculty. For this hackathon, it isn't a suitable platform. |
+| Microsoft Azure | Azure has a [Free Tier](https://azure.microsoft.com/en-us/free/); many common services are free to use and ***new customers get a $200 platform credit***. | Azure offers [a special platform credit for students](https://azure.microsoft.com/en-us/free/free-account-students-faq/); ***a $100 platform credit is included and registration for Azure for Students does not require a credit card on file***. |
 
 ## Platform Credits
 
@@ -67,3 +67,43 @@ pages:
 Note that Azure for Students and AWS Educate may take several business days to be set 
 up; applying for access to these platforms 2 weeks before the hackathon is recommended 
 if you don't want to use a standard free tier account during the event.
+
+## Cost Management
+
+For enterprise-level applications, there can be significant monthly bills 
+from cloud providers. Typically these applications produce millions of 
+service activities from thousands of users, and the organization hosting 
+these applications have a business model to support the costs.
+
+As students, our needs are substantially different from those of a 
+company with seed funding and revenue streams. Even so, it is easy to burn 
+through a substantial amount of money without realizing it.
+
+### Culprits of Unexpected Costs
+
+Each user's needs will be different, but there are a few common gotchas 
+which tend to inflate AWS costs: 
+
+* Unused or underutilized virtual machines (EC2 instances)
+* Unused or underutilized peripherals for EC2 instances (static IP reservations, storage volumes)
+* Data transfer costs associated with EBS or S3
+
+The primary lessons here are to clean up resources which you don't need 
+and research the costs of services which you plan on utilizing heavily. 
+[Read more about the 'gotchas' here.](https://www.itproportal.com/features/7-hidden-aws-costs-that-could-be-killing-your-budget/)
+
+Many of AWS's hidden or unexpected costs also apply to GCP and Azure. 
+
+### Preventing Unexpected Costs
+
+At scale, GCP seems to be the friendlier platform for cost management than AWS, 
+and they have significant advantages in specific service niches.
+GCP also allows you to set budgets and monitor cost utilization 
+[in a more granular fashion](https://cloud.google.com/billing/docs/how-to/budgets) than 
+[AWS billing monitoring](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html).
+
+ For enterprise systems and corporate customers, 
+[Azure may provide advantages and disadvantages](https://www.informationweek.com/cloud/infrastructure-as-a-service/hidden-cloud-costs-aws-azure-management-costs-compared/a/d-id/1298029) 
+depending on the existing system configuration, but for students, the 
+difference is likely not noticable.
+

--- a/_docs/whatiscloud.md
+++ b/_docs/whatiscloud.md
@@ -30,7 +30,7 @@ You bet. Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (
 Try shipping your machine to the customer, then get back to me. Really though, it’s because the applications that you can create in the cloud can be far more capable than what you can create on your machine. Web hosting, machine learning, databases, serverless functions and more are at your fingertips allowing you to build applications in a way you never could before.
 
 ### Alright, you've convinced me. So how do I get started?
-Head to [our guide on cloud providers](_docs/cloud_account_setup.md) and follow the exquisitely detailed instructions to learn how to signup for a free account and get free student credits on each cloud platform. It is highly recommended to peruse the documentation for each offering you want to use. Links to AWS, Azure, and GCP documentation websites have been provided for your convenience.
+Head to [our guide on cloud providers](cloud_setup.html) and follow the exquisitely detailed instructions to learn how to signup for a free account and get free student credits on each cloud platform. It is highly recommended to peruse the documentation for each offering you want to use. Links to AWS, Azure, and GCP documentation websites have been provided for your convenience.
 * [AWS Documentation](https://docs.aws.amazon.com/index.html)
 * [Azure Documentation](https://docs.microsoft.com/en-us/azure/)
 * [GCP Documentation](https://cloud.google.com/docs/)


### PR DESCRIPTION
I put the cart before the horse and didn't test locally to ensure HTML tags would render as expected. Apparently, the Jekyll rendering schema is not like GitHub's native markdown rendering, and as such, HTML content in markdown tables doesn't get rendered as HTML.

This is the primary table before:

![awful_layout](https://user-images.githubusercontent.com/29528527/73725379-1cebf380-46e2-11ea-8a8e-386505ed0746.png)

This is the table after:
![better_layout](https://user-images.githubusercontent.com/29528527/73725737-d77bf600-46e2-11ea-9614-8ad18276ccb4.png)

The changes here separate free account creation from cost management strategies; I think this is an altogether better flow for the content.
