### PR TITLE
Fixed missing link to example projects in Cloud FAQ

### DIFF
--- a/_docs/whatiscloud.md
+++ b/_docs/whatiscloud.md
@@ -20,7 +20,7 @@ There are two kinds of offerings that you might see when browsing a cloud provid
 * Services, on the other hand, abstract away the nitty-gritty implementation details. Services allow you to build and deploy your application without worrying about the underlying details. For example, Amazon’s AWS Lambda service allows you to deploy functions that contain regular code. AWS might run your code in a VM, or in a Container. The key thing to remember here is, *it doesn’t matter to you*. Most cloud offerings fall into the Services category, and they make developing cloud applications much easier than it might appear.
 
 ### Intriguing...so what can I do in the cloud?
-Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [LINK TO EXAMPLE PROJECTS] for a few concrete examples.
+Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [our collection of example projects](project-ideas.html) for a few concrete examples.
 
 ### Wait, there's more than one cloud provider?
 You bet. Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (GCP) are the three most well-known cloud providers out there today, but they aren’t the only ones. In order to keep these docs coherent (and us, sane) we’ll be focusing on these three.

--- a/_docs/whatiscloud.md
+++ b/_docs/whatiscloud.md
@@ -20,7 +20,7 @@ There are two kinds of offerings that you might see when browsing a cloud provid
 * Services, on the other hand, abstract away the nitty-gritty implementation details. Services allow you to build and deploy your application without worrying about the underlying details. For example, Amazon’s AWS Lambda service allows you to deploy functions that contain regular code. AWS might run your code in a VM, or in a Container. The key thing to remember here is, *it doesn’t matter to you*. Most cloud offerings fall into the Services category, and they make developing cloud applications much easier than it might appear.
 
 ### Intriguing...so what can I do in the cloud?
-Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [our collection of example projects](project_ideas.html) for a few concrete examples.
+Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [our collection of example projects]({% link _docs/project-ideas.md %}) for a few concrete examples.
 
 ### Wait, there's more than one cloud provider?
 You bet. Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (GCP) are the three most well-known cloud providers out there today, but they aren’t the only ones. In order to keep these docs coherent (and us, sane) we’ll be focusing on these three.
@@ -37,4 +37,3 @@ Head to [our guide on cloud providers](_docs/cloud_account_setup.md) and follow 
 
 ### Is this stuff really free???
 There is no such thing as a free lunch. More to the point though, each provider has a set of “always free” offerings, and a set of free trial offerings. All free offerings have usage limitations which will be clearly marked on the provider’s website. **Exceeding the listed limitations will incur charges which you will be responsible for.** Cloud providers will email you when you use credits or have a new invoice posted. Keep track of these communications and avoid leaving services running in order to minimize potential charges. Free trials typically last 12 months, after which you will be charged for any offering that is not in the “always free” category. Student accounts can often be renewed at the provider’s discretion.
-

--- a/_docs/whatiscloud.md
+++ b/_docs/whatiscloud.md
@@ -20,7 +20,7 @@ There are two kinds of offerings that you might see when browsing a cloud provid
 * Services, on the other hand, abstract away the nitty-gritty implementation details. Services allow you to build and deploy your application without worrying about the underlying details. For example, Amazon’s AWS Lambda service allows you to deploy functions that contain regular code. AWS might run your code in a VM, or in a Container. The key thing to remember here is, *it doesn’t matter to you*. Most cloud offerings fall into the Services category, and they make developing cloud applications much easier than it might appear.
 
 ### Intriguing...so what can I do in the cloud?
-Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [our collection of example projects](project-ideas.html) for a few concrete examples.
+Almost anything you can dream of. Cloud providers are constantly improving and adding to their offerings. A good place to start would be to take a simple application that you could run locally, such as an app that retrieves and stores information in a database and move it into the cloud. Refer to [our collection of example projects](project_ideas.html) for a few concrete examples.
 
 ### Wait, there's more than one cloud provider?
 You bet. Amazon Web Services (AWS), Microsoft Azure, and Google Cloud Platform (GCP) are the three most well-known cloud providers out there today, but they aren’t the only ones. In order to keep these docs coherent (and us, sane) we’ll be focusing on these three.


### PR DESCRIPTION
Changed [LINK TO EXAMPLE PROJECTS] to the actual link to project-ideas.html.